### PR TITLE
Bump nictiz versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,8 @@ build: install-dependencies convert-drawio build-ig
 # Install dependencies
 .PHONY: install-dependencies
 install-dependencies:
-	@echo "Installing nictiz packages from local zip file..."
-	@mkdir -p $(HOME)/.fhir/packages
-	@unzip -o nictiz-packages/nictiz.fhir.nl.r4-with-snapshots.zip -d $(HOME)/.fhir/packages/
-	@echo "Nictiz packages installed successfully"
-	@echo "Fixing 4.0.x versions in nictiz packages (for Publisher 2.0.15 compatibility)..."
-	@python3 scripts/fix_nictiz_dependencies.py
+	@fhir install nictiz.fhir.nl.r4.zib2020@0.12.0-beta.4
+	@fhir inflate --package nictiz.fhir.nl.r4.zib2020@0.12.0-beta.4
 
 # Build Implementation Guide (Full with documentation)
 .PHONY: build-ig

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -22,11 +22,11 @@ publisher:
   # email: test@example.org
 dependencies:
   nictiz.fhir.nl.r4.zib2020:
-    version: 0.11.0-beta.1
-    uri: http://simplifier.net/packages/nictiz.fhir.nl.r4.zib2020#0.11.0-beta.1
+    version: 0.12.0-beta.4
+    uri: http://simplifier.net/packages/nictiz.fhir.nl.r4.zib2020#0.12.0-beta.4
   nictiz.fhir.nl.r4.nl-core:
-    version: 0.11.0-beta.1
-    uri: http://simplifier.net/packages/nictiz.fhir.nl.r4.nl-core#0.11.0-beta.1
+    version: 0.12.0-beta.4
+    uri: http://simplifier.net/packages/nictiz.fhir.nl.r4.nl-core#0.12.0-beta.4
 
 # The dependencies property corresponds to IG.dependsOn. The key is the
 # package id and the value is the version (or dev/current). For advanced


### PR DESCRIPTION
Update `sushi-config.yaml` dependencies to version 0.12.0-beta.4 for `nictiz.fhir.nl.r4.zib2020` and `nictiz.fhir.nl.r4.nl-core`